### PR TITLE
Add SkyHarvest landing page with Eco-Dashboard and new visual theme

### DIFF
--- a/juanpa/frontend/public/skyharvest-preview.html
+++ b/juanpa/frontend/public/skyharvest-preview.html
@@ -1,0 +1,698 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SkyHarvest · Futuristic Vertical Farming</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: light;
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: 'Space Grotesk', system-ui, sans-serif;
+        background: #f7f9fb;
+        color: #0f172a;
+        line-height: 1.6;
+      }
+
+      .skyharvest {
+        background: linear-gradient(180deg, #ffffff 0%, #f6f7fb 40%, #eff7ff 100%);
+        min-height: 100vh;
+      }
+
+      .skyharvest__hero {
+        padding: 48px 6vw 60px;
+        background: radial-gradient(circle at top, rgba(124, 58, 237, 0.08), transparent 45%),
+          linear-gradient(120deg, rgba(34, 197, 94, 0.08), transparent 45%);
+      }
+
+      .skyharvest__nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 48px;
+      }
+
+      .skyharvest__logo {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-weight: 700;
+        font-size: 1.2rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .skyharvest__logo-mark {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border-radius: 12px;
+        background: linear-gradient(135deg, #7c3aed, #38bdf8);
+        color: white;
+        font-size: 0.8rem;
+      }
+
+      .skyharvest__nav-links {
+        display: flex;
+        gap: 16px;
+      }
+
+      .ghost-button {
+        background: transparent;
+        border: 1px solid rgba(15, 23, 42, 0.15);
+        color: #0f172a;
+        padding: 10px 18px;
+        border-radius: 999px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.2s ease;
+      }
+
+      .ghost-button:hover {
+        border-color: #7c3aed;
+        color: #7c3aed;
+        box-shadow: 0 6px 16px rgba(124, 58, 237, 0.15);
+      }
+
+      .skyharvest__hero-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 40px;
+        align-items: center;
+      }
+
+      .skyharvest__hero-copy h1 {
+        font-size: clamp(2.4rem, 2.8vw, 3.6rem);
+        margin: 16px 0;
+        max-width: 520px;
+      }
+
+      .eyebrow {
+        text-transform: uppercase;
+        letter-spacing: 0.2em;
+        font-size: 0.75rem;
+        color: #4c1d95;
+        font-weight: 700;
+      }
+
+      .hero-subtitle {
+        font-size: 1.1rem;
+        max-width: 520px;
+        color: #475569;
+      }
+
+      .hero-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        margin: 24px 0;
+      }
+
+      .primary-button,
+      .secondary-button {
+        border-radius: 999px;
+        padding: 12px 24px;
+        font-weight: 700;
+        border: none;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .primary-button {
+        background: linear-gradient(135deg, #7c3aed, #22c55e);
+        color: white;
+        box-shadow: 0 10px 30px rgba(34, 197, 94, 0.2);
+      }
+
+      .secondary-button {
+        background: white;
+        border: 1px solid rgba(15, 23, 42, 0.2);
+        color: #0f172a;
+      }
+
+      .primary-button:hover,
+      .secondary-button:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 12px 24px rgba(56, 189, 248, 0.18);
+      }
+
+      .hero-metrics {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 16px;
+        margin-top: 32px;
+      }
+
+      .hero-metrics span {
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: #0f172a;
+      }
+
+      .hero-metrics p {
+        color: #64748b;
+        margin-top: 4px;
+        font-size: 0.9rem;
+      }
+
+      .skyharvest__hero-visual {
+        display: grid;
+        gap: 20px;
+      }
+
+      .visual-panel {
+        position: relative;
+        overflow: hidden;
+        border-radius: 20px;
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+        border: 1px solid rgba(148, 163, 184, 0.3);
+      }
+
+      .visual-panel img {
+        width: 100%;
+        height: 240px;
+        object-fit: cover;
+        filter: saturate(1.2) brightness(1.08);
+      }
+
+      .visual-overlay {
+        position: absolute;
+        inset: auto 0 0 0;
+        padding: 16px 20px;
+        background: rgba(15, 23, 42, 0.65);
+        color: white;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      .section-heading {
+        max-width: 680px;
+        margin-bottom: 32px;
+      }
+
+      .section-heading h2 {
+        font-size: clamp(1.8rem, 2.4vw, 2.6rem);
+        margin-bottom: 8px;
+      }
+
+      .section-heading p {
+        color: #475569;
+      }
+
+      .skyharvest__stack,
+      .skyharvest__dashboard,
+      .skyharvest__crops {
+        padding: 64px 6vw;
+      }
+
+      .stack-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 20px;
+      }
+
+      .stack-module {
+        background: white;
+        border-radius: 16px;
+        padding: 20px;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
+        display: grid;
+        gap: 8px;
+      }
+
+      .stack-status {
+        align-self: start;
+        color: #22c55e;
+        font-weight: 700;
+        font-size: 0.75rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .dashboard-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 24px;
+        align-items: start;
+      }
+
+      .dashboard-metrics {
+        display: grid;
+        gap: 16px;
+      }
+
+      .metric-card {
+        background: white;
+        border-radius: 18px;
+        padding: 24px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+      }
+
+      .metric-card h3 {
+        font-size: 2rem;
+        margin: 10px 0;
+      }
+
+      .metric-detail {
+        color: #64748b;
+        font-size: 0.85rem;
+      }
+
+      .dashboard-visuals {
+        display: grid;
+        gap: 16px;
+      }
+
+      .line-card {
+        background: rgba(255, 255, 255, 0.9);
+        border-radius: 18px;
+        padding: 18px 20px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        box-shadow: 0 10px 26px rgba(15, 23, 42, 0.08);
+      }
+
+      .line-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-weight: 600;
+        margin-bottom: 12px;
+      }
+
+      .line-status {
+        font-size: 0.7rem;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: #38bdf8;
+      }
+
+      .line-graph {
+        stroke-dasharray: 320;
+        stroke-dashoffset: 320;
+        animation: draw-line 3s ease infinite;
+      }
+
+      @keyframes draw-line {
+        0% {
+          stroke-dashoffset: 320;
+        }
+        60% {
+          stroke-dashoffset: 0;
+        }
+        100% {
+          stroke-dashoffset: 0;
+        }
+      }
+
+      .crop-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 20px;
+      }
+
+      .crop-card {
+        position: relative;
+        background: white;
+        border-radius: 20px;
+        padding: 22px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+        overflow: hidden;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .crop-card:hover {
+        transform: translateY(-4px);
+        box-shadow: 0 18px 38px rgba(124, 58, 237, 0.2);
+      }
+
+      .crop-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 10px;
+      }
+
+      .crop-meta {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 0.85rem;
+        color: #64748b;
+      }
+
+      .chip {
+        background: rgba(34, 197, 94, 0.15);
+        color: #16a34a;
+        padding: 4px 10px;
+        border-radius: 999px;
+        font-size: 0.65rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .holo-popup {
+        position: absolute;
+        inset: 20px;
+        background: rgba(15, 23, 42, 0.88);
+        border-radius: 16px;
+        padding: 18px;
+        color: white;
+        opacity: 0;
+        pointer-events: none;
+        transform: translateY(10px);
+        transition: all 0.2s ease;
+        border: 1px solid rgba(124, 58, 237, 0.6);
+        box-shadow: 0 0 30px rgba(56, 189, 248, 0.4);
+      }
+
+      .crop-card:hover .holo-popup {
+        opacity: 1;
+        transform: translateY(0);
+      }
+
+      .skyharvest__cta {
+        padding: 64px 6vw 80px;
+        background: linear-gradient(120deg, rgba(124, 58, 237, 0.1), rgba(56, 189, 248, 0.1));
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 24px;
+      }
+
+      .skyharvest__cta h2 {
+        margin-bottom: 8px;
+      }
+
+      @media (max-width: 720px) {
+        .skyharvest__nav {
+          flex-direction: column;
+          gap: 16px;
+        }
+
+        .skyharvest__nav-links {
+          flex-wrap: wrap;
+          justify-content: center;
+        }
+
+        .skyharvest__cta {
+          flex-direction: column;
+          text-align: center;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="skyharvest">
+      <header class="skyharvest__hero">
+        <nav class="skyharvest__nav">
+          <div class="skyharvest__logo">
+            <span class="skyharvest__logo-mark">◆</span>
+            SkyHarvest
+          </div>
+          <div class="skyharvest__nav-links">
+            <button class="ghost-button">Platform</button>
+            <button class="ghost-button">Eco-Dashboard</button>
+            <button class="ghost-button">Contact</button>
+          </div>
+        </nav>
+        <div class="skyharvest__hero-grid">
+          <div class="skyharvest__hero-copy">
+            <p class="eyebrow">Urban Agriculture, Reimagined</p>
+            <h1>Vertical farming engineered like a cleanroom lab.</h1>
+            <p class="hero-subtitle">
+              SkyHarvest delivers pesticide-free produce through precision hydroponics, stacked modules,
+              and AI-driven growth recipes. Farming becomes an urban science — luminous, sterile, and
+              efficient.
+            </p>
+            <div class="hero-actions">
+              <button class="primary-button">Tour the Facility</button>
+              <button class="secondary-button">Download Spec Sheet</button>
+            </div>
+            <div class="hero-metrics">
+              <div>
+                <span>98%</span>
+                <p>Water reclaimed per cycle</p>
+              </div>
+              <div>
+                <span>24/7</span>
+                <p>Climate orchestration</p>
+              </div>
+              <div>
+                <span>0</span>
+                <p>Soil contaminants detected</p>
+              </div>
+            </div>
+          </div>
+          <div class="skyharvest__hero-visual">
+            <div class="visual-panel">
+              <img
+                src="https://images.unsplash.com/photo-1545239351-ef35f43d514b?auto=format&fit=crop&w=900&q=80"
+                alt="Sterile vertical farming tower with LED lighting"
+              />
+              <div class="visual-overlay">
+                <p>Layered hydroponic towers</p>
+                <span>Photon Density: 98 μmol/m²</span>
+              </div>
+            </div>
+            <div class="visual-panel">
+              <img
+                src="https://images.unsplash.com/photo-1501004318641-b39e6451bec6?auto=format&fit=crop&w=900&q=80"
+                alt="Crisp lettuce under artificial LED lighting"
+              />
+              <div class="visual-overlay">
+                <p>Clean-growth produce</p>
+                <span>Zero pesticide residue</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section class="skyharvest__stack">
+        <div class="section-heading">
+          <h2>Modular vertical stacks for city infrastructure.</h2>
+          <p>
+            Each SkyHarvest cell is a self-contained ecosystem — a grid-based architecture that scales
+            across rooftops, warehouses, and subterranean hubs.
+          </p>
+        </div>
+        <div class="stack-grid">
+          <div class="stack-module">
+            <h3>Tier 1</h3>
+            <p>Independent nutrient loop, LED spectrum tailoring, and sterile airflow.</p>
+            <span class="stack-status">Active</span>
+          </div>
+          <div class="stack-module">
+            <h3>Tier 2</h3>
+            <p>Precision dosing for leafy greens and aromatic herbs.</p>
+            <span class="stack-status">Active</span>
+          </div>
+          <div class="stack-module">
+            <h3>Tier 3</h3>
+            <p>Adaptive airflow and humidity control optimized per cultivar.</p>
+            <span class="stack-status">Active</span>
+          </div>
+          <div class="stack-module">
+            <h3>Tier 4</h3>
+            <p>Closed-loop irrigation with UV sterilization.</p>
+            <span class="stack-status">Active</span>
+          </div>
+          <div class="stack-module">
+            <h3>Tier 5</h3>
+            <p>Automated harvest lanes and AI yield prediction.</p>
+            <span class="stack-status">Active</span>
+          </div>
+          <div class="stack-module">
+            <h3>Tier 6</h3>
+            <p>Cold-chain ready storage and packaging layer.</p>
+            <span class="stack-status">Active</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="skyharvest__dashboard" id="dashboard">
+        <div class="section-heading">
+          <h2>Eco-Dashboard · Live Metrics</h2>
+          <p>Real-time sustainability impact from every harvest cycle.</p>
+        </div>
+        <div class="dashboard-grid">
+          <div class="dashboard-metrics">
+            <div class="metric-card">
+              <p>Water Saved</p>
+              <h3><span class="counter" data-target="12840">0</span> L</h3>
+              <span class="metric-detail">Compared to field irrigation</span>
+            </div>
+            <div class="metric-card">
+              <p>Carbon Offset</p>
+              <h3><span class="counter" data-target="3420">0</span> kg</h3>
+              <span class="metric-detail">Renewable energy matched</span>
+            </div>
+            <div class="metric-card">
+              <p>Daily Harvest Yield</p>
+              <h3><span class="counter" data-target="980">0</span> kg</h3>
+              <span class="metric-detail">Average across 42 modules</span>
+            </div>
+          </div>
+          <div class="dashboard-visuals">
+            <div class="line-card">
+              <div class="line-header">
+                <span>Nutrient Flow</span>
+                <span class="line-status">Live</span>
+              </div>
+              <svg viewBox="0 0 200 80" aria-hidden="true">
+                <polyline
+                  class="line-graph"
+                  points="10,61 46,43 82,54 118,30 154,41 190,23"
+                  fill="none"
+                  stroke="url(#skyGradient)"
+                  stroke-width="3"
+                ></polyline>
+                <defs>
+                  <linearGradient id="skyGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+                    <stop offset="0%" stop-color="#7c3aed" />
+                    <stop offset="50%" stop-color="#38bdf8" />
+                    <stop offset="100%" stop-color="#22c55e" />
+                  </linearGradient>
+                </defs>
+              </svg>
+            </div>
+            <div class="line-card">
+              <div class="line-header">
+                <span>Photon Output</span>
+                <span class="line-status">Live</span>
+              </div>
+              <svg viewBox="0 0 200 80" aria-hidden="true">
+                <polyline
+                  class="line-graph"
+                  points="10,62 46,48 82,56 118,36 154,39 190,27"
+                  fill="none"
+                  stroke="url(#skyGradient)"
+                  stroke-width="3"
+                ></polyline>
+              </svg>
+            </div>
+            <div class="line-card">
+              <div class="line-header">
+                <span>Growth Velocity</span>
+                <span class="line-status">Live</span>
+              </div>
+              <svg viewBox="0 0 200 80" aria-hidden="true">
+                <polyline
+                  class="line-graph"
+                  points="10,59 46,45 82,50 118,34 154,37 190,20"
+                  fill="none"
+                  stroke="url(#skyGradient)"
+                  stroke-width="3"
+                ></polyline>
+              </svg>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="skyharvest__crops">
+        <div class="section-heading">
+          <h2>Crop intelligence layer</h2>
+          <p>Hover to reveal holographic nutrition and growth data streams.</p>
+        </div>
+        <div class="crop-grid">
+          <div class="crop-card">
+            <div class="crop-header">
+              <h3>Basil</h3>
+              <span class="chip">Bio-Optimized</span>
+            </div>
+            <p>High-menthol microgreens tuned for rapid cycles.</p>
+            <div class="crop-meta">
+              <span>Vitamin K · 62% DV</span>
+              <span>18-day growth</span>
+            </div>
+            <div class="holo-popup">
+              <h4>Nutrition Scan</h4>
+              <p>Vitamin K · 62% DV</p>
+              <p>18-day growth</p>
+              <p>Yield: 1.8 kg / m²</p>
+            </div>
+          </div>
+          <div class="crop-card">
+            <div class="crop-header">
+              <h3>Butterhead Lettuce</h3>
+              <span class="chip">Bio-Optimized</span>
+            </div>
+            <p>Soft-leaf cultivar optimized for LED density.</p>
+            <div class="crop-meta">
+              <span>Folate · 42% DV</span>
+              <span>24-day growth</span>
+            </div>
+            <div class="holo-popup">
+              <h4>Nutrition Scan</h4>
+              <p>Folate · 42% DV</p>
+              <p>24-day growth</p>
+              <p>Yield: 3.1 kg / m²</p>
+            </div>
+          </div>
+          <div class="crop-card">
+            <div class="crop-header">
+              <h3>Micro Kale</h3>
+              <span class="chip">Bio-Optimized</span>
+            </div>
+            <p>Compact nutrient stacks for urban kitchens.</p>
+            <div class="crop-meta">
+              <span>Vitamin C · 71% DV</span>
+              <span>16-day growth</span>
+            </div>
+            <div class="holo-popup">
+              <h4>Nutrition Scan</h4>
+              <p>Vitamin C · 71% DV</p>
+              <p>16-day growth</p>
+              <p>Yield: 1.2 kg / m²</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="skyharvest__cta">
+        <div>
+          <h2>Deploy a SkyHarvest lab in your city.</h2>
+          <p>We partner with urban developers and grocers to install modular, carbon-negative farms.</p>
+        </div>
+        <button class="primary-button">Schedule a Demo</button>
+      </section>
+    </div>
+
+    <script>
+      const counters = document.querySelectorAll('.counter');
+      const updateCounters = () => {
+        counters.forEach((counter) => {
+          const target = Number(counter.dataset.target || 0);
+          const current = Number(counter.textContent || 0);
+          const increment = Math.ceil(target / 120);
+          if (current < target) {
+            counter.textContent = Math.min(current + increment, target).toLocaleString();
+          }
+        });
+      };
+
+      setInterval(updateCounters, 60);
+    </script>
+  </body>
+</html>

--- a/juanpa/frontend/src/App.css
+++ b/juanpa/frontend/src/App.css
@@ -1,42 +1,407 @@
+:root {
+  color-scheme: light;
+}
+
+body {
+  margin: 0;
+  background: #f7f9fb;
+  color: #0f172a;
+}
+
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  max-width: none;
+  padding: 0;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.skyharvest {
+  background: linear-gradient(180deg, #ffffff 0%, #f6f7fb 40%, #eff7ff 100%);
+  color: #0f172a;
+  min-height: 100vh;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.skyharvest__hero {
+  padding: 48px 6vw 60px;
+  background: radial-gradient(circle at top, rgba(124, 58, 237, 0.08), transparent 45%),
+    linear-gradient(120deg, rgba(34, 197, 94, 0.08), transparent 45%);
+}
+
+.skyharvest__nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 48px;
+}
+
+.skyharvest__logo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 700;
+  font-size: 1.2rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.skyharvest__logo-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #7c3aed, #38bdf8);
+  color: white;
+  font-size: 0.8rem;
+}
+
+.skyharvest__nav-links {
+  display: flex;
+  gap: 16px;
+}
+
+.ghost-button {
+  background: transparent;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  color: #0f172a;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.ghost-button:hover {
+  border-color: #7c3aed;
+  color: #7c3aed;
+  box-shadow: 0 6px 16px rgba(124, 58, 237, 0.15);
+}
+
+.skyharvest__hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 40px;
+  align-items: center;
+}
+
+.skyharvest__hero-copy h1 {
+  font-size: clamp(2.4rem, 2.8vw, 3.6rem);
+  margin: 16px 0;
+  max-width: 520px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  color: #4c1d95;
+  font-weight: 700;
+}
+
+.hero-subtitle {
+  font-size: 1.1rem;
+  max-width: 520px;
+  color: #475569;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin: 24px 0;
+}
+
+.primary-button,
+.secondary-button {
+  border-radius: 999px;
+  padding: 12px 24px;
+  font-weight: 700;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, #7c3aed, #22c55e);
+  color: white;
+  box-shadow: 0 10px 30px rgba(34, 197, 94, 0.2);
+}
+
+.secondary-button {
+  background: white;
+  border: 1px solid rgba(15, 23, 42, 0.2);
+  color: #0f172a;
+}
+
+.primary-button:hover,
+.secondary-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(56, 189, 248, 0.18);
+}
+
+.hero-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 16px;
+  margin-top: 32px;
+}
+
+.hero-metrics span {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.hero-metrics p {
+  color: #64748b;
+  margin-top: 4px;
+  font-size: 0.9rem;
+}
+
+.skyharvest__hero-visual {
+  display: grid;
+  gap: 20px;
+}
+
+.visual-panel {
+  position: relative;
+  overflow: hidden;
+  border-radius: 20px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.visual-panel img {
+  width: 100%;
+  height: 240px;
+  object-fit: cover;
+  filter: saturate(1.2) brightness(1.08);
+}
+
+.visual-overlay {
+  position: absolute;
+  inset: auto 0 0 0;
+  padding: 16px 20px;
+  background: rgba(15, 23, 42, 0.65);
+  color: white;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.section-heading {
+  max-width: 680px;
+  margin-bottom: 32px;
+}
+
+.section-heading h2 {
+  font-size: clamp(1.8rem, 2.4vw, 2.6rem);
+  margin-bottom: 8px;
+}
+
+.section-heading p {
+  color: #475569;
+}
+
+.skyharvest__stack,
+.skyharvest__dashboard,
+.skyharvest__crops {
+  padding: 64px 6vw;
+}
+
+.stack-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.stack-module {
+  background: white;
+  border-radius: 16px;
+  padding: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
+  display: grid;
+  gap: 8px;
+}
+
+.stack-status {
+  align-self: start;
+  color: #22c55e;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+  align-items: start;
+}
+
+.dashboard-metrics {
+  display: grid;
+  gap: 16px;
+}
+
+.metric-card {
+  background: white;
+  border-radius: 18px;
+  padding: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+}
+
+.metric-card h3 {
+  font-size: 2rem;
+  margin: 10px 0;
+}
+
+.metric-detail {
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.dashboard-visuals {
+  display: grid;
+  gap: 16px;
+}
+
+.line-card {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 18px;
+  padding: 18px 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 10px 26px rgba(15, 23, 42, 0.08);
+}
+
+.line-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.line-status {
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #38bdf8;
+}
+
+.line-graph {
+  stroke-dasharray: 320;
+  stroke-dashoffset: 320;
+  animation: draw-line 3s ease infinite;
+}
+
+@keyframes draw-line {
+  0% {
+    stroke-dashoffset: 320;
   }
-  to {
-    transform: rotate(360deg);
+  60% {
+    stroke-dashoffset: 0;
+  }
+  100% {
+    stroke-dashoffset: 0;
   }
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+.crop-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.crop-card {
+  position: relative;
+  background: white;
+  border-radius: 20px;
+  padding: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.crop-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 38px rgba(124, 58, 237, 0.2);
+}
+
+.crop-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.crop-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.chip {
+  background: rgba(34, 197, 94, 0.15);
+  color: #16a34a;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.holo-popup {
+  position: absolute;
+  inset: 20px;
+  background: rgba(15, 23, 42, 0.88);
+  border-radius: 16px;
+  padding: 18px;
+  color: white;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(10px);
+  transition: all 0.2s ease;
+  border: 1px solid rgba(124, 58, 237, 0.6);
+  box-shadow: 0 0 30px rgba(56, 189, 248, 0.4);
+}
+
+.crop-card.is-active .holo-popup {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.skyharvest__cta {
+  padding: 64px 6vw 80px;
+  background: linear-gradient(120deg, rgba(124, 58, 237, 0.1), rgba(56, 189, 248, 0.1));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.skyharvest__cta h2 {
+  margin-bottom: 8px;
+}
+
+@media (max-width: 720px) {
+  .skyharvest__nav {
+    flex-direction: column;
+    gap: 16px;
   }
-}
 
-.card {
-  padding: 2em;
-}
+  .skyharvest__nav-links {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
 
-.read-the-docs {
-  color: #888;
+  .skyharvest__cta {
+    flex-direction: column;
+    text-align: center;
+  }
 }

--- a/juanpa/frontend/src/App.tsx
+++ b/juanpa/frontend/src/App.tsx
@@ -1,100 +1,255 @@
-import { Routes, Route, Link, NavLink } from 'react-router-dom';
-import './App.css'; // Puedes mantener o modificar los estilos globales
-import 'react-tooltip/dist/react-tooltip.css'; // Importar CSS de react-tooltip
-import { Tooltip } from 'react-tooltip';      // Importar Tooltip
+import { useEffect, useMemo, useState } from 'react';
+import './App.css';
 
-// Importa las páginas/componentes que usarás en las rutas
-import DeckListPage from './pages/DeckListPage'; 
-import CreateDeckPage from './pages/CreateDeckPage'; 
-import DeckDetailPage from './pages/DeckDetailPage'; 
-import CreateCardPage from './pages/CreateCardPage'; 
-import ReviewPage from './pages/ReviewPage'; 
-import StatsPage from './pages/StatsPage'; 
-import ImportPage from './pages/ImportPage'; 
-import EditDeckPage from './pages/EditDeckPage'; 
-import EditCardPage from './pages/EditCardPage'; // Importar EditCardPage
-import QuickCapturePage from './pages/QuickCapturePage'; // Importar QuickCapturePage
-import SettingsPage from './pages/SettingsPage'; // Importar SettingsPage
-import AIGeneratorPage from './pages/AIGeneratorPage'; // Importar AIGeneratorPage
-import HelpPage from './pages/HelpPage'; // Importar HelpPage
-import SyncButton from './components/SyncButton'; // Importar SyncButton
-import OfflineIndicator from './components/OfflineIndicator'; // Importar OfflineIndicator
+const METRIC_TARGETS = {
+  water: 12840,
+  carbon: 3420,
+  harvest: 980,
+};
 
-function SomeOtherPage() { // Componente de ejemplo, se puede mantener o eliminar
+const CROPS = [
+  {
+    name: 'Basil',
+    summary: 'High-menthol microgreens tuned for rapid cycles.',
+    nutrition: 'Vitamin K · 62% DV',
+    cycle: '18-day growth',
+    yield: '1.8 kg / m²',
+  },
+  {
+    name: 'Butterhead Lettuce',
+    summary: 'Soft-leaf cultivar optimized for LED density.',
+    nutrition: 'Folate · 42% DV',
+    cycle: '24-day growth',
+    yield: '3.1 kg / m²',
+  },
+  {
+    name: 'Micro Kale',
+    summary: 'Compact nutrient stacks for urban kitchens.',
+    nutrition: 'Vitamin C · 71% DV',
+    cycle: '16-day growth',
+    yield: '1.2 kg / m²',
+  },
+];
+
+const LINE_DATA = [
+  { label: 'Nutrient Flow', values: [10, 30, 18, 45, 32, 52] },
+  { label: 'Photon Output', values: [8, 24, 16, 38, 35, 48] },
+  { label: 'Growth Velocity', values: [12, 28, 22, 40, 36, 55] },
+];
+
+const App = () => {
+  const [metrics, setMetrics] = useState({ water: 0, carbon: 0, harvest: 0 });
+  const [activeCrop, setActiveCrop] = useState<string | null>(null);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setMetrics((prev) => ({
+        water: Math.min(prev.water + 84, METRIC_TARGETS.water),
+        carbon: Math.min(prev.carbon + 24, METRIC_TARGETS.carbon),
+        harvest: Math.min(prev.harvest + 12, METRIC_TARGETS.harvest),
+      }));
+    }, 60);
+
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const linePaths = useMemo(() => {
+    return LINE_DATA.map((line) => {
+      const points = line.values
+        .map((value, index) => {
+          const x = (index / (line.values.length - 1)) * 180 + 10;
+          const y = 70 - value * 0.9;
+          return `${x},${y}`;
+        })
+        .join(' ');
+
+      return {
+        label: line.label,
+        points,
+      };
+    });
+  }, []);
+
   return (
-    <div>
-      <h2>Otra Página</h2>
-      <p>Contenido de otra página.</p>
-      <Link to="/">Volver a Inicio</Link>
-    </div>
-  );
-}
-
-const App: React.FC = () => {
-  return (
-    <div className="App">
-      <OfflineIndicator />
-      <header className="app-nav">
-        <nav style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0 20px' }}>
-          <div style={{ display: 'flex', gap: '10px' }}>
-            <NavLink to="/" end>
-              <span role="img" aria-label="Inicio" className="nav-icon">🏠</span> Inicio
-            </NavLink>
-            <NavLink to="/decks/new" className={({ isActive }) => isActive ? "active nav-button-compact" : "nav-button-compact"}>
-              <span role="img" aria-label="Crear Mazo" className="nav-icon">➕</span> Crear
-            </NavLink>
-            <NavLink to="/quick-capture" className={({ isActive }) => isActive ? "active nav-button-compact" : "nav-button-compact"}>
-              <span role="img" aria-label="Captura OCR" className="nav-icon">📸</span> OCR
-            </NavLink>
-            <NavLink to="/ai-generator" className={({ isActive }) => isActive ? "active nav-button-compact" : "nav-button-compact"}>
-              <span role="img" aria-label="IA Generador" className="nav-icon">🤖</span> IA
-            </NavLink>
-            <NavLink to="/review">
-              <span role="img" aria-label="Repasar" className="nav-icon">🔄</span> Repasar
-            </NavLink>
-            <NavLink to="/stats">
-              <span role="img" aria-label="Estadísticas" className="nav-icon">📊</span> Stats
-            </NavLink>
-            <NavLink to="/import" className={({ isActive }) => isActive ? "active nav-button-compact" : "nav-button-compact"}>
-              <span role="img" aria-label="Importar" className="nav-icon">📥</span> Import
-            </NavLink>
+    <div className="skyharvest">
+      <header className="skyharvest__hero">
+        <nav className="skyharvest__nav">
+          <div className="skyharvest__logo">
+            <span className="skyharvest__logo-mark">◆</span>
+            SkyHarvest
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-            <NavLink to="/settings" className={({ isActive }) => isActive ? "active nav-button-compact" : "nav-button-compact"}>
-              <span role="img" aria-label="Configuraciones" className="nav-icon">⚙️</span>
-            </NavLink>
-            <NavLink to="/help" className={({ isActive }) => isActive ? "active nav-button-compact" : "nav-button-compact"}>
-              <span role="img" aria-label="Ayuda" className="nav-icon">📖</span>
-            </NavLink>
-            <SyncButton showStatus={false} />
+          <div className="skyharvest__nav-links">
+            <button className="ghost-button">Platform</button>
+            <button className="ghost-button">Eco-Dashboard</button>
+            <button className="ghost-button">Contact</button>
           </div>
         </nav>
+        <div className="skyharvest__hero-grid">
+          <div className="skyharvest__hero-copy">
+            <p className="eyebrow">Urban Agriculture, Reimagined</p>
+            <h1>Vertical farming engineered like a cleanroom lab.</h1>
+            <p className="hero-subtitle">
+              SkyHarvest delivers pesticide-free produce through precision hydroponics, stacked modules,
+              and AI-driven growth recipes. Farming becomes an urban science — luminous, sterile, and
+              efficient.
+            </p>
+            <div className="hero-actions">
+              <button className="primary-button">Tour the Facility</button>
+              <button className="secondary-button">Download Spec Sheet</button>
+            </div>
+            <div className="hero-metrics">
+              <div>
+                <span>98%</span>
+                <p>Water reclaimed per cycle</p>
+              </div>
+              <div>
+                <span>24/7</span>
+                <p>Climate orchestration</p>
+              </div>
+              <div>
+                <span>0</span>
+                <p>Soil contaminants detected</p>
+              </div>
+            </div>
+          </div>
+          <div className="skyharvest__hero-visual">
+            <div className="visual-panel">
+              <img
+                src="https://images.unsplash.com/photo-1545239351-ef35f43d514b?auto=format&fit=crop&w=900&q=80"
+                alt="Sterile vertical farming tower with LED lighting"
+              />
+              <div className="visual-overlay">
+                <p>Layered hydroponic towers</p>
+                <span>Photon Density: 98 μmol/m²</span>
+              </div>
+            </div>
+            <div className="visual-panel">
+              <img
+                src="https://images.unsplash.com/photo-1501004318641-b39e6451bec6?auto=format&fit=crop&w=900&q=80"
+                alt="Crisp lettuce under artificial LED lighting"
+              />
+              <div className="visual-overlay">
+                <p>Clean-growth produce</p>
+                <span>Zero pesticide residue</span>
+              </div>
+            </div>
+          </div>
+        </div>
       </header>
-      <main>
-        <Routes>
-          <Route path="/" element={<DeckListPage />} />
-          <Route path="/decks/new" element={<CreateDeckPage />} />
-          <Route path="/decks/:deckId" element={<DeckDetailPage />} />
-          <Route path="/decks/:deckId/edit" element={<EditDeckPage />} /> 
-          <Route path="/cards/create" element={<CreateCardPage />} />
-          <Route path="/cards/edit/:cardId" element={<EditCardPage />} />
-          <Route path="/quick-capture" element={<QuickCapturePage />} />
-          <Route path="/ai-generator" element={<AIGeneratorPage />} />
-          <Route path="/study/:deckId" element={<ReviewPage />} />
-          <Route path="/review" element={<ReviewPage />} />
-          <Route path="/stats" element={<StatsPage />} /> 
-          <Route path="/import" element={<ImportPage />} /> 
-          <Route path="/settings" element={<SettingsPage />} />
-          <Route path="/help" element={<HelpPage />} />
-          <Route path="/some-other-page" element={<SomeOtherPage />} /> 
-        </Routes>
-      </main>
-      <footer>
-        {/* Pie de página si es necesario */}
-      </footer>
-      <Tooltip id="heatmap-tooltip" /> {/* Añadir el componente Tooltip aquí */}
+
+      <section className="skyharvest__stack">
+        <div className="section-heading">
+          <h2>Modular vertical stacks for city infrastructure.</h2>
+          <p>
+            Each SkyHarvest cell is a self-contained ecosystem — a grid-based architecture that scales
+            across rooftops, warehouses, and subterranean hubs.
+          </p>
+        </div>
+        <div className="stack-grid">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div key={index} className="stack-module">
+              <h3>Tier {index + 1}</h3>
+              <p>Independent nutrient loop, LED spectrum tailoring, and sterile airflow.</p>
+              <span className="stack-status">Active</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="skyharvest__dashboard">
+        <div className="section-heading">
+          <h2>Eco-Dashboard · Live Metrics</h2>
+          <p>Real-time sustainability impact from every harvest cycle.</p>
+        </div>
+        <div className="dashboard-grid">
+          <div className="dashboard-metrics">
+            <div className="metric-card">
+              <p>Water Saved</p>
+              <h3>{metrics.water.toLocaleString()} L</h3>
+              <span className="metric-detail">Compared to field irrigation</span>
+            </div>
+            <div className="metric-card">
+              <p>Carbon Offset</p>
+              <h3>{metrics.carbon.toLocaleString()} kg</h3>
+              <span className="metric-detail">Renewable energy matched</span>
+            </div>
+            <div className="metric-card">
+              <p>Daily Harvest Yield</p>
+              <h3>{metrics.harvest.toLocaleString()} kg</h3>
+              <span className="metric-detail">Average across 42 modules</span>
+            </div>
+          </div>
+          <div className="dashboard-visuals">
+            {linePaths.map((line) => (
+              <div key={line.label} className="line-card">
+                <div className="line-header">
+                  <span>{line.label}</span>
+                  <span className="line-status">Live</span>
+                </div>
+                <svg viewBox="0 0 200 80" aria-hidden="true">
+                  <polyline
+                    className="line-graph"
+                    points={line.points}
+                    fill="none"
+                    stroke="url(#skyGradient)"
+                    strokeWidth="3"
+                  />
+                  <defs>
+                    <linearGradient id="skyGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+                      <stop offset="0%" stopColor="#7c3aed" />
+                      <stop offset="50%" stopColor="#38bdf8" />
+                      <stop offset="100%" stopColor="#22c55e" />
+                    </linearGradient>
+                  </defs>
+                </svg>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="skyharvest__crops">
+        <div className="section-heading">
+          <h2>Crop intelligence layer</h2>
+          <p>Hover to reveal holographic nutrition and growth data streams.</p>
+        </div>
+        <div className="crop-grid">
+          {CROPS.map((crop) => (
+            <div
+              key={crop.name}
+              className={`crop-card ${activeCrop === crop.name ? 'is-active' : ''}`}
+              onMouseEnter={() => setActiveCrop(crop.name)}
+              onMouseLeave={() => setActiveCrop(null)}
+            >
+              <div className="crop-header">
+                <h3>{crop.name}</h3>
+                <span className="chip">Bio-Optimized</span>
+              </div>
+              <p>{crop.summary}</p>
+              <div className="crop-meta">
+                <span>{crop.nutrition}</span>
+                <span>{crop.cycle}</span>
+              </div>
+              <div className="holo-popup" aria-hidden={activeCrop !== crop.name}>
+                <h4>Nutrition Scan</h4>
+                <p>{crop.nutrition}</p>
+                <p>{crop.cycle}</p>
+                <p>Yield: {crop.yield}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="skyharvest__cta">
+        <div>
+          <h2>Deploy a SkyHarvest lab in your city.</h2>
+          <p>We partner with urban developers and grocers to install modular, carbon-negative farms.</p>
+        </div>
+        <button className="primary-button">Schedule a Demo</button>
+      </section>
     </div>
   );
-}
+};
 
 export default App;


### PR DESCRIPTION
### Motivation
- Replace the existing app shell with a focused, futuristic landing experience that positions SkyHarvest as a clinical, urban vertical-farming platform. 
- Present farming as a clean, high-tech science using a laboratory-white palette with LED purples, vital greens and sky blues and a stacked/grid layout that echoes vertical towers. 
- Surface live sustainability metrics and interactive crop data so the home page reads as both marketing and an "Eco-Dashboard" for operations.

### Description
- Implement a new single-page React landing component at `frontend/src/App.tsx` that provides a hero, modular stack section, an animated Eco-Dashboard (rolling counters and SVG line visuals), a crop intelligence grid with hover-triggered holographic popups, and a CTA. 
- Add crafted styles in `frontend/src/App.css` to realize the cleanroom aesthetic, grid-based module layout, LED-accent gradients, line-draw animation, holo popup styling, and responsive behavior. 
- Include mock data arrays (`METRIC_TARGETS`, `LINE_DATA`, `CROPS`) and client-side metric animation logic to simulate live counters and graphs for the dashboard. 
- Use externally hosted photography placeholders and SVG gradients to keep the changes visual-first and self-contained in the frontend assets.

### Testing
- Attempted to start the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, but the command failed due to a missing Rollup optional native dependency (`@rollup/rollup-linux-x64-gnu`) causing the dev server not to start. 
- No automated unit or integration tests were run as this is primarily a visual/UI change and the local dev server could not be launched. 
- Visual verification was not possible in this environment because the dev server startup failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698575d84db0832fa8c73196eefa3e43)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI rewrite of the app entrypoint that effectively removes access to existing routed functionality without changing the router/bootstrap code; low security risk but high chance of breaking expected navigation/user flows.
> 
> **Overview**
> Replaces the existing multi-route flashcard app shell in `App.tsx` (nav, pages, routing, sync/offline UI, tooltips) with a single-page SkyHarvest landing experience (hero, modular stack section, Eco-Dashboard metrics with animated counters, SVG “live” line cards, crop cards with hover-triggered holographic popups, and a CTA).
> 
> Overhauls `App.css` to drop the prior Vite starter styles and introduce a new cleanroom/LED visual theme (global layout reset, gradients, grid layouts, animations, responsive breakpoints), including state-driven `is-active` styling for crop popups.
> 
> Adds `public/skyharvest-preview.html`, a standalone static mock of the same landing page for quick preview outside the React app.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c8030523284199c0ed3d9144a972eb944683a66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->